### PR TITLE
Fix Swift 6 data race diagnostic for FlutterResult

### DIFF
--- a/flutter_charset_detector_darwin/darwin/flutter_charset_detector_darwin/Sources/flutter_charset_detector_darwin/FlutterCharsetDetectorPlugin.swift
+++ b/flutter_charset_detector_darwin/darwin/flutter_charset_detector_darwin/Sources/flutter_charset_detector_darwin/FlutterCharsetDetectorPlugin.swift
@@ -39,9 +39,7 @@ public class FlutterCharsetDetectorPlugin: NSObject, FlutterPlugin {
             case "detect":
                 handleDetect(call, resultWrapper)
             default:
-                DispatchQueue.main.async {
-                    result(FlutterError(code: "UnsupportedMethod", message: "\(call.method) is not supported", details: nil))
-                }
+                resultWrapper(FlutterError(code: "UnsupportedMethod", message: "\(call.method) is not supported", details: nil))
             }
         }
     }

--- a/flutter_charset_detector_darwin/darwin/flutter_charset_detector_darwin/Sources/flutter_charset_detector_darwin/FlutterCharsetDetectorPlugin.swift
+++ b/flutter_charset_detector_darwin/darwin/flutter_charset_detector_darwin/Sources/flutter_charset_detector_darwin/FlutterCharsetDetectorPlugin.swift
@@ -31,6 +31,12 @@ public class FlutterCharsetDetectorPlugin: NSObject, FlutterPlugin {
             nonisolated(unsafe) let result = result
             DispatchQueue.main.async { result(value) }
         }
+        let errorWrapper = { (code: String, message: String, details: String?) in
+            nonisolated(unsafe) let result = result
+            DispatchQueue.main.async {
+                result(FlutterError(code: code, message: message, details: details))
+            }
+        }
         nonisolated(unsafe) let call = call
         DispatchQueue.global(qos: .userInitiated).async { [self] in
             switch call.method {
@@ -39,7 +45,7 @@ public class FlutterCharsetDetectorPlugin: NSObject, FlutterPlugin {
             case "detect":
                 handleDetect(call, resultWrapper)
             default:
-                resultWrapper(FlutterError(code: "UnsupportedMethod", message: "\(call.method) is not supported", details: nil))
+                errorWrapper("UnsupportedMethod", "\(call.method) is not supported", nil)
             }
         }
     }


### PR DESCRIPTION
## Summary
- avoid sending non-Sendable FlutterError across dispatch queues
- keep unsupported method error construction on the main queue

Fix build failure in latest Xcode:
<img width="900" height="138" alt="image" src="https://github.com/user-attachments/assets/a20dfcb5-8cd2-4af3-baae-0970e354e1cd" />

## Testing
- downstream iOS Flutter build passes